### PR TITLE
#4 actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -67,7 +67,8 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        # uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./public
 


### PR DESCRIPTION
Deprecation notice: v1, v2, and v3 of the artifact actions

The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "github-pages". Please update your workflow to use v4 of the artifact actions. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

see: https://github.com/ulynks/www/actions/runs/12447092560